### PR TITLE
add Xaloqi EDS — ISO 14229 UDS diagnostics stack for Zephyr

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 - [S2OPC](https://gitlab.com/systerel/S2OPC) - Open-source OPC-UA Toolkit designed with security and embedded devices in mind.
 - [libcsp](https://github.com/libcsp/libcsp) - A small network-layer delivery protocol designed for Cubesats.
 - [requests](https://github.com/walidbadar/requests) - A simple interface to perform common HTTP operations.
+- [Xaloqi EDS](https://github.com/Xaloqi/EDS) - ISO 14229 (UDS) diagnostics stack with ISO-TP and DoIP transports, ASIL-B safety wrappers, and YAML-driven code generation for CAN-capable boards.
 
 ### Security
 


### PR DESCRIPTION
## Summary

Adds [Xaloqi EDS](https://github.com/Xaloqi/EDS) to the **Networking & Protocols** section.

Xaloqi EDS is a production-grade ISO 14229 (UDS) diagnostics stack for Zephyr RTOS:

- 14 UDS services: 0x10 0x11 0x14 0x19 0x22 0x27 0x28 0x2E 0x31 0x34 0x36 0x37 0x3E 0x85
- Full ISO-TP transport per ISO 15765-2 (SF/FF/CF/FC + CAN FD extensions §9.8)
- DoIP transport per ISO 13400-2
- ASIL-B safety wrappers — MISRA C:2012 zero violations
- YAML-driven codegen (C handlers, pytest suite, CANoe CAPL)
- Tested on native_sim (CI) and Nucleo-H743ZI2 (CAN hardware)
- 14 CI jobs green, 37 unit tests + 68 harness integration tests + 439-test robustness campaign

**License:** GPL v2 (runtime), Apache 2.0 (examples)  
**Repo:** https://github.com/Xaloqi/EDS  
**Latest release:** delivery-v1.7.2 (2026-06-20)  
**Docs:** https://xaloqi.com  

The repo contains a `zephyr/module.yml` so it can be consumed as a west module by adding to a workspace `west.yml`:

```yaml
remotes:
  - name: xaloqi
    url-base: https://github.com/Xaloqi
projects:
  - name: EDS
    remote: xaloqi
    revision: delivery-v1.7.2
    path: modules/diag/xaloqi-eds
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)